### PR TITLE
Fix broken LightStep link

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Note that the all-in-one docker image presents the Jaeger UI at [localhost:16686
 
 #### LightStep
 
-If you have access to [LightStep](https://app.lightstep.com]), you will need your access token. Add the following to `ls_config.properties`:
+If you have access to [LightStep](https://go.lightstep.com/tracing.html), you will need your access token. Add the following to `ls_config.properties`:
 
 ```properties
 ls.accessToken=XXXXXXXXXXXXXXX  // TODO: replace with your token


### PR DESCRIPTION
* Original link had an extra "]" character which made it invalid
* Changed link to be directly to the sign-up for convenience (presumably most people coming through the README will need to sign-up rather than login)