### PR TITLE
Update our Jetty version.

### DIFF
--- a/microdonuts/pom.xml
+++ b/microdonuts/pom.xml
@@ -23,7 +23,7 @@
     <dependency>
       <groupId>org.eclipse.jetty</groupId>
       <artifactId>jetty-server</artifactId>
-      <version>9.4.5.v20170502</version>
+      <version>9.4.17.v20190418</version>
     </dependency>
     <dependency>
       <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
The previous one had a security vulnerability,
and its unavailability in Maven was breaking the build.